### PR TITLE
Fix sign_symbol_for with Rails 4.0.1

### DIFF
--- a/lib/zodiac/finder.rb
+++ b/lib/zodiac/finder.rb
@@ -54,7 +54,7 @@ module Zodiac
   private
     def self.sign_symbol_for(date)
       RANGES.each do |range, sign|
-        if range.days.include? date_for(date[:month], date[:day])
+        if range.days.cover? date_for(date[:month], date[:day])
           return sign
         end
       end


### PR DESCRIPTION
Uses the "cover?" method because "include?" is no longer allowed on DateTime in Rails 4.0.1 for performance reasons. This also increases performance!
